### PR TITLE
Update dmarc-xml-0.2.xsd

### DIFF
--- a/dmarc-xml-0.2.xsd
+++ b/dmarc-xml-0.2.xsd
@@ -173,7 +173,7 @@
  <xs:restriction base="xs:string">
   <!-- IPv4 -->
   <xs:pattern value=
-  "(\d|[1-9]\d|1\d\d|2[0-4]\d|25[0-5]\.){3}(\d|[1-9]\d|1\d\d|2[0-4]\d|25[0-5])"/>
+  "((\d|[1-9]\d|1\d\d|2[0-4]\d|25[0-5])\.){3}(\d|[1-9]\d|1\d\d|2[0-4]\d|25[0-5])"/>
   <!-- IPv6 -->
   <xs:pattern value="([A-Fa-f\d]{1,4}:){7}[A-Fa-f\d]{1,4}"/>
   <!-- RFC 5952 zero compression IPv6 (lax) -->


### PR DESCRIPTION
IPv4 regular expression does not match IPv4 addresses due to the dot (.) being matched as part of the '25[0-5]' branch instead of the 0-255 number pattern.