### PR TITLE
Ipv6 regex update

### DIFF
--- a/dmarc-xml-0.2.xsd
+++ b/dmarc-xml-0.2.xsd
@@ -175,22 +175,14 @@
   <xs:pattern value=
   "((\d|[1-9]\d|1\d\d|2[0-4]\d|25[0-5])\.){3}(\d|[1-9]\d|1\d\d|2[0-4]\d|25[0-5])"/>
   <!-- IPv6 -->
-  <xs:pattern value="([A-Fa-f\d]{1,4}:){7}[A-Fa-f\d]{1,4}"/>
-  <!-- RFC 5952 zero compression IPv6 (lax) -->
-  <xs:pattern value="([A-Fa-f\d]{1,4}:){1,7}:"/>
-  <xs:pattern value="([A-Fa-f\d]{1,4}:){1,6}:[A-Fa-f\d]{1,4}"/>
-  <xs:pattern value=
-  "([A-Fa-f\d]{1,4}:){1,5}:[A-Fa-f\d]{1,4}:[A-Fa-f\d]{1,4}"/>
-  <xs:pattern value=
-  "([A-Fa-f\d]{1,4}:){1,4}:([A-Fa-f\d]{1,4}:){1,2}[A-Fa-f\d]{1,4}"/>
-  <xs:pattern value=
-  "([A-Fa-f\d]{1,4}:){1,3}:([A-Fa-f\d]{1,4}:){1,3}[A-Fa-f\d]{1,4}"/>
-  <xs:pattern value=
-  "([A-Fa-f\d]{1,4}:){1,2}:([A-Fa-f\d]{1,4}:){1,4}[A-Fa-f\d]{1,4}"/>
-  <xs:pattern value=
-  "[A-Fa-f\d]{1,4}::([A-Fa-f\d]{1,4}:){1,5}[A-Fa-f\d]{1,4}"/>
-  <xs:pattern value="::([A-Fa-f\d]{1,4}:){1,6}[A-Fa-f\d]{1,4}"/>
-  <xs:pattern value="::[A-Fa-f\d]{1,4}"/>
+  <xs:pattern value="((0|[a-f1-9][a-f\d]{0,3}):){7}(0|[a-f1-9][a-f\d]{0,3})"/>
+  <xs:pattern value="((0|[a-f1-9][a-f\d]{0,3}):){1,6}"/>
+  <xs:pattern value="((0|[a-f1-9][a-f\d]{0,3}):){1,5}:(0|[a-f1-9][a-f\d]{0,3})"/>
+  <xs:pattern value="((0|[a-f1-9][a-f\d]{0,3}):){1,4}(:(0|[a-f1-9][a-f\d]{0,3})){1,2}"/>
+  <xs:pattern value="((0|[a-f1-9][a-f\d]{0,3}):){1,3}(:(0|[a-f1-9][a-f\d]{0,3})){1,3}"/>
+  <xs:pattern value="((0|[a-f1-9][a-f\d]{0,3}):){1,2}(:(0|[a-f1-9][a-f\d]{0,3})){1,4}"/>
+  <xs:pattern value="(0|[a-f1-9][a-f\d]{0,3}):(:(0|[a-f1-9][a-f\d]{0,3})){1,5}"/>
+  <xs:pattern value=":(:(0|[a-f1-9][a-f\d]{0,3})){1,6}"/>
  </xs:restriction>
 </xs:simpleType>
 

--- a/dmarc-xml-0.2.xsd
+++ b/dmarc-xml-0.2.xsd
@@ -171,10 +171,11 @@
 <!-- The Internet Protocol Address from which messages were received -->
 <xs:simpleType name="IPAddress">
  <xs:restriction base="xs:string">
-  <!-- IPv4 -->
+  <!-- A globally routable IPv4 unicast address in the dotted-decimal format -->
   <xs:pattern value=
   "((\d|[1-9]\d|1\d\d|2[0-4]\d|25[0-5])\.){3}(\d|[1-9]\d|1\d\d|2[0-4]\d|25[0-5])"/>
-  <!-- IPv6 -->
+  <!-- A globally routable IPv6 Global Unicast address in the canonical
+       textual representation format; see RFC 5952 for details -->
   <xs:pattern value="((0|[a-f1-9][a-f\d]{0,3}):){7}(0|[a-f1-9][a-f\d]{0,3})"/>
   <xs:pattern value="((0|[a-f1-9][a-f\d]{0,3}):){1,6}"/>
   <xs:pattern value="((0|[a-f1-9][a-f\d]{0,3}):){1,5}:(0|[a-f1-9][a-f\d]{0,3})"/>


### PR DESCRIPTION
Update the IPv6 regular expressions to match the canonical textual representation format specified in RFC 5952.
Adjust the comments to clearly spell out what type of addresses we expect to see.